### PR TITLE
Added option to hide op declarations and fixed write_schema/2.

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -1,7 +1,7 @@
 name( rdfs2pl ).
 title( 'Compile an RDFS schema to prolog predicates' ).
 keywords([semweb,rdf,schema,ontology]).
-version( '0.0.2' ).
+version( '0.0.3' ).
 author('Chris Mungall','cmungall@gmail.com').
 home('https://github.com/cmungall/rdfs2pl').
 download('https://github.com/cmungall/rdfs2pl.git').

--- a/prolog/rdfs2pl.pl
+++ b/prolog/rdfs2pl.pl
@@ -1,22 +1,25 @@
 /* -*- Mode: Prolog -*- */
 
-/** 
-
-**/
-
 :- module(rdfs2pl,
           [assert_schema/2,
-           write_schema/3]).
+           assert_schema/1,
+           write_schema/3,
+           write_schema/2]).
 
 :- use_module(library(semweb/rdf_db)).
 :- use_module(library(semweb/rdfs)).
+
 
 assert_schema(Local,Global):-
         rdf_register_ns(Local,Global),
         assert_clauses(Local).
 
+assert_schema(Local):-
+        rdf_current_prefix(Local,_),
+        assert_clauses(Local).
+
 assert_clauses(M):-
-        forall(inf_clause(M,X),
+        forall(inf_clause(M,X,[]),
                M:assert(X)).
 
 %% write_schema(Prefix,Global,+Opts)
@@ -26,7 +29,7 @@ write_schema(Local,Opts):-
         write_schema(Local,_,Opts).
 write_schema(Local,Global,Opts):-
         (   var(Global)
-        ->  rdf_current_prefix(uberon,Global)
+        ->  rdf_current_prefix(Local,Global)
         ;   rdf_register_ns(Local,Global)),
         write_module_schema(Local,[module(Local)|Opts]).
 
@@ -174,6 +177,7 @@ inf_export( NS, F/N, Opts ):-
         functor(Term,F,N).
 
 inf_export( NS, op(300,xfy,F), Opts ):-
+        option(ops(true),Opts,true),
         property(R),
         maketerm(R,[], NS:F,Opts).
 


### PR DESCRIPTION
Hi,
I've just been trying out your rdfs2pl pack and found a little bug in write_schema/3 which was preventing it from working with a namespace/prefix that was already defined. I also added an option to prevent operator declarations and a couple of minor fixes to get rid of some warnings. In particular, I assumed that the call to inf_clause/2 should have been a call to inf_clause/3 with no options.
Thanks for the code!
Samer.
